### PR TITLE
Fix minor spelling and formating errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ As of now, this is still WIP, although the core features are implemented.
 ## Installation
 
 You can compile the plugin by running `mvn package` (note, make sure
-you have the [in-toto-java jar available](https://github.com/controlplaneio/in-toto-java).
+you have the [in-toto-java jar available](https://github.com/controlplaneio/in-toto-java))
 and manually install the `.hpi` file in your Jenkins installation.
 
 We intend to move this to the plugin site for Jenkins once a more mature
@@ -20,13 +20,15 @@ implementation is reached.
 This plugin exposes a "post build" entry in the task menu. When selecting it
 you will be prompted to fill the following information in:
 
-- stepName: the name of the step for this Jenkins pipeline (more on that later)
-- credentialId: Id of File Credential as the signing key used to sign the link metada. *
-- keyPath: the path to the signing key used to sign the link metadata. *
+- stepName: the name of the step for this Jenkins pipeline (more on that later).
+- credentialId: Id of File Credential as the signing key used to sign the link
+  metadata. &ast;
+- keyPath: the path to the signing key used to sign the link metadata. &ast;
 - transport: a URI to where to post the metadata upon
   completion.
 
-* You should either fill the credentialId or keyPath to assgin a key for signing the link metadata.
+&ast; You should either fill the credentialId or keyPath to assign a key for
+signing the link metadata.
 
 Once this is done, the plugin will take care of generating and tracking
 information of the build process.
@@ -35,7 +37,7 @@ information of the build process.
 
 You can also use it in declarative pipelines by using the `in_toto_wrap`
 syntax. It takes the same arguments as before. For example, to wrap a simple
-shellscript step you would add the following to your Jenkinisfile:
+shell script step you would add the following to your Jenkinsfile:
 
 ```
 
@@ -65,15 +67,15 @@ POST request with the link metadata.
 If using the keypath parameter, the path must be located on the remote worker. The plugin uses a
 `MasterToSlave` handler to serialize in-toto code to capture the in-toto
 metadata natively in any worker. This both serves to not expose the slave's key
-unecessarilly in the Master's filesystem and to authenticate any worker that
+unnecessarily in the master's filesystem and to authenticate any worker that
 performed the pipeline step.
 
 ### Using transports:
 
-The transport is chosen by specifying the protocol header on the uri. For
+The transport is chosen by specifying the protocol header on the URI. For
 example, for a redis transport you'd use `redis://` and for an etcd transport
 you'd specify `etcd://`. `https` and `http` are handled using a generic HTTP
-POST request with the link metadata as the body of the request. 
+POST request with the link metadata as the body of the request.
 
 You can easily extend transports by extending the abstract class `Transport` in
 the `io.jenkins.plugins.intotorecorder.transport` package. Discovery of new


### PR DESCRIPTION
- Fix some typos and punctuation
- Make acronym capitalization uniform (URI)
- Make "footnote" asterisk literal